### PR TITLE
Casbin v2.30 support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,7 @@ module github.com/casbin/redis-watcher/v2
 go 1.14
 
 require (
-	github.com/casbin/casbin/v2 v2.26.1
+	github.com/casbin/casbin/v2 v2.30.0
 	github.com/go-redis/redis/v8 v8.8.0
 	github.com/google/uuid v1.2.0
 )
-

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible h1
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/casbin/casbin/v2 v2.26.1 h1:82ruJHV5ZLJyfca8M+d4TsrZfGvC3FHUcLvQMqzb9LQ=
 github.com/casbin/casbin/v2 v2.26.1/go.mod h1:vByNa/Fchek0KZUgG5wEsl7iFsiviAYKRtgrQfcJqHg=
+github.com/casbin/casbin/v2 v2.30.0 h1:bBUyn1xgI+AApUDAPK+G7aw1Ln+dbKMIdqKFwOzhz/4=
+github.com/casbin/casbin/v2 v2.30.0/go.mod h1:vByNa/Fchek0KZUgG5wEsl7iFsiviAYKRtgrQfcJqHg=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=


### PR DESCRIPTION
Since Casbin v2.30 added `sec` and `ptype` params to WatcherEx methods in https://github.com/casbin/casbin/pull/776, `redis-watcher` also needs to be updated with new interface.
With this PR, watcher handler will receive `sec`, `ptype`, and `params`, so that other nodes will be able to identify the changes.