### PR TITLE
fix: json marshalling error with private members

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -27,8 +27,8 @@ type Watcher struct {
 type MSG struct {
 	Method string
 	ID     string
-	sec    string
-	ptype  string
+	Sec    string
+	Ptype  string
 	Params interface{}
 }
 


### PR DESCRIPTION
Based on https://github.com/casbin/redis-watcher/pull/5  changes, there was a json marshaling bug with `sec` and `ptype` params. The struct member had to be public.
