### PR TITLE
fix: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Redis Watcher is a [Redis](http://redis.io) watcher for [Casbin](https://github.
 
 ## Installation
 
-    go get github.com/casbin/redis-watcher
+    go get github.com/casbin/redis-watcher/v2
 
 ## Simple Example
 
@@ -21,7 +21,7 @@ import (
 	"log"
 
 	"github.com/casbin/casbin/v2"
-	watcher "github.com/casbin/redis-watcher"
+	watcher "github.com/casbin/redis-watcher/v2"
 	"github.com/go-redis/redis/v8"
 )
 


### PR DESCRIPTION
Cannot use `go get` command following current README.md instruction. It turns out 
![image](https://user-images.githubusercontent.com/46557895/120908080-91012780-c699-11eb-8a50-c1fce307847d.png)
the repo from `pkg.go.dev` has a different address from the README.md. 

And seems that there is a discrepancy between GitHub's tag version and the one on `pkg.go.dev`?
![image](https://user-images.githubusercontent.com/46557895/120908123-dfaec180-c699-11eb-92b6-c6c5dc2b7861.png)
vs
![image](https://user-images.githubusercontent.com/46557895/120908128-e76e6600-c699-11eb-9de2-73e91643047a.png)

Signed-off-by: ffyuanda <46557895+ffyuanda@users.noreply.github.com>