### PR TITLE
perf: remove unnecessary init config

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -55,13 +55,13 @@ func NewWatcher(addr string, option WatcherOptions) (persist.Watcher, error) {
 	option.Addr = addr
 	initConfig(&option)
 	w := &Watcher{
-		subClient: rds.NewClient(&option.Options),
-		pubClient: rds.NewClient(&option.Options),
-		ctx:       context.Background(),
-		close:     make(chan struct{}),
+		ctx:   context.Background(),
+		close: make(chan struct{}),
 	}
 
-	w.initConfig(option)
+	if err := w.initConfig(option); err != nil {
+		return nil, err
+	}
 
 	if err := w.subClient.Ping(w.ctx).Err(); err != nil {
 		return nil, err


### PR DESCRIPTION
The CL involved are as follows:
- w.initConfig handle error.
- remove unnecessary config `subClient` and `pubClient`
https://github.com/casbin/redis-watcher/blob/e68fa4e76cfc39565a51cbdb2803def9cfc0ddf1/watcher.go#L93-L103