### PR TITLE
[feat] Add default WatcherEx update callback

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,8 +1,13 @@
 package rediswatcher
 
 import (
+	"errors"
+	"github.com/casbin/casbin/v2"
 	rds "github.com/go-redis/redis/v8"
 	"github.com/google/uuid"
+	"log"
+	"strconv"
+	"strings"
 )
 
 type WatcherOptions struct {
@@ -21,5 +26,56 @@ func initConfig(option *WatcherOptions) {
 	}
 	if option.Channel == "" {
 		option.Channel = "/casbin"
+	}
+}
+
+func MakeDefaultUpdateCallback(e *casbin.Enforcer) func(string) {
+	return func(msg string) {
+		msgStruct := &MSG{}
+
+		err := msgStruct.UnmarshalBinary([]byte(msg))
+		if err != nil {
+			log.Println(err)
+		}
+
+		e.EnableAutoNotifyWatcher(false)
+
+		switch msgStruct.Method {
+		case UpdateType_Update:
+		case UpdateType_UpdateForSavePolicy:
+			err = e.LoadPolicy()
+		case UpdateType_UpdateForAddPolicy:
+			params := msgStruct.Params[0]
+
+			_, err = e.AddPolicy(params)
+		case UpdateType_UpdateForRemovePolicy:
+			params := msgStruct.Params[0]
+
+			_, err = e.RemovePolicy(params)
+		case UpdateType_UpdateForRemoveFilteredPolicy:
+			params := msgStruct.Params[0][0]
+
+			// parse the result of fmt.Sprintf("%d %s", fieldIndex, strings.Join(fieldValues, " "))
+			paramsList := strings.Fields(params)
+			fieldIndex, _ := strconv.Atoi(paramsList[0])
+			fieldValues := paramsList[1:]
+
+			_, err = e.RemoveFilteredPolicy(fieldIndex, fieldValues...)
+		case UpdateType_UpdateForAddPolicies:
+			params := msgStruct.Params
+
+			_, err = e.AddPolicies(params)
+		case UpdateType_UpdateForRemovePolicies:
+			params := msgStruct.Params
+
+			_, err = e.RemovePolicies(params)
+		default:
+			err = errors.New("unknown update type")
+		}
+		if err != nil {
+			log.Println(err)
+		}
+
+		e.EnableAutoNotifyWatcher(true)
 	}
 }

--- a/watcher.go
+++ b/watcher.go
@@ -180,7 +180,7 @@ func (w *Watcher) UpdateForSavePolicy(model model.Model) error {
 	return w.logRecord(func() error {
 		w.l.Lock()
 		defer w.l.Unlock()
-		return w.pubClient.Publish(context.Background(), w.options.Channel, &MSG{"UpdateForSavePolicy", w.options.LocalID, "", "", model}).Err()
+		return w.pubClient.Publish(context.Background(), w.options.Channel, &MSG{"UpdateForSavePolicy", w.options.LocalID, "", "", ""}).Err()
 	})
 }
 

--- a/watcher.go
+++ b/watcher.go
@@ -29,8 +29,20 @@ type MSG struct {
 	ID     string
 	Sec    string
 	Ptype  string
-	Params interface{}
+	Params [][]string
 }
+
+type UpdateType = string
+
+const (
+	UpdateType_Update                        UpdateType = "Update"
+	UpdateType_UpdateForAddPolicy            UpdateType = "UpdateForAddPolicy"
+	UpdateType_UpdateForRemovePolicy         UpdateType = "UpdateForRemovePolicy"
+	UpdateType_UpdateForRemoveFilteredPolicy UpdateType = "UpdateForRemoveFilteredPolicy"
+	UpdateType_UpdateForSavePolicy           UpdateType = "UpdateForSavePolicy"
+	UpdateType_UpdateForAddPolicies          UpdateType = "UpdateForAddPolicies"
+	UpdateType_UpdateForRemovePolicies       UpdateType = "UpdateForRemovePolicies"
+)
 
 func (m *MSG) MarshalBinary() ([]byte, error) {
 	return json.Marshal(m)
@@ -61,7 +73,7 @@ func NewWatcher(addr string, option WatcherOptions) (persist.Watcher, error) {
 		close:     make(chan struct{}),
 	}
 
-	w.initConfig(option)
+	_ = w.initConfig(option)
 
 	if err := w.subClient.Ping(w.ctx).Err(); err != nil {
 		return nil, err
@@ -134,7 +146,7 @@ func (w *Watcher) Update() error {
 	return w.logRecord(func() error {
 		w.l.Lock()
 		defer w.l.Unlock()
-		return w.pubClient.Publish(context.Background(), w.options.Channel, &MSG{"Update", w.options.LocalID, "", "", ""}).Err()
+		return w.pubClient.Publish(context.Background(), w.options.Channel, &MSG{"Update", w.options.LocalID, "", "", nil}).Err()
 	})
 }
 
@@ -144,7 +156,7 @@ func (w *Watcher) UpdateForAddPolicy(sec, ptype string, params ...string) error 
 	return w.logRecord(func() error {
 		w.l.Lock()
 		defer w.l.Unlock()
-		return w.pubClient.Publish(context.Background(), w.options.Channel, &MSG{"UpdateForAddPolicy", w.options.LocalID, sec, ptype, params}).Err()
+		return w.pubClient.Publish(context.Background(), w.options.Channel, &MSG{"UpdateForAddPolicy", w.options.LocalID, sec, ptype, [][]string{params}}).Err()
 	})
 }
 
@@ -154,7 +166,7 @@ func (w *Watcher) UpdateForRemovePolicy(sec, ptype string, params ...string) err
 	return w.logRecord(func() error {
 		w.l.Lock()
 		defer w.l.Unlock()
-		return w.pubClient.Publish(context.Background(), w.options.Channel, &MSG{"UpdateForRemovePolicy", w.options.LocalID, sec, ptype, params}).Err()
+		return w.pubClient.Publish(context.Background(), w.options.Channel, &MSG{"UpdateForRemovePolicy", w.options.LocalID, sec, ptype, [][]string{params}}).Err()
 	})
 }
 
@@ -168,7 +180,7 @@ func (w *Watcher) UpdateForRemoveFilteredPolicy(sec, ptype string, fieldIndex in
 			&MSG{"UpdateForRemoveFilteredPolicy", w.options.LocalID,
 				sec,
 				ptype,
-				fmt.Sprintf("%d %s", fieldIndex, strings.Join(fieldValues, " ")),
+				[][]string{{fmt.Sprintf("%d %s", fieldIndex, strings.Join(fieldValues, " "))}},
 			},
 		).Err()
 	})
@@ -180,7 +192,7 @@ func (w *Watcher) UpdateForSavePolicy(model model.Model) error {
 	return w.logRecord(func() error {
 		w.l.Lock()
 		defer w.l.Unlock()
-		return w.pubClient.Publish(context.Background(), w.options.Channel, &MSG{"UpdateForSavePolicy", w.options.LocalID, "", "", ""}).Err()
+		return w.pubClient.Publish(context.Background(), w.options.Channel, &MSG{"UpdateForSavePolicy", w.options.LocalID, "", "", nil}).Err()
 	})
 }
 

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -1,11 +1,8 @@
 package rediswatcher
 
 import (
-	"encoding/json"
 	"fmt"
-	"github.com/casbin/casbin/v2/model"
 	"log"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -152,17 +149,9 @@ func TestUpdateSavePolicy(t *testing.T) {
 			if ID != w.options.LocalID {
 				t.Fatalf("instance ID should be %s instead of %s", w.options.LocalID, ID)
 			}
-			s := `{"e":{"e":{"Key":"e","Value":"some(where (p_eft == allow))","Tokens":null,"Policy":null,"PolicyMap":{},"RM":null}},"g":{"g":{"Key":"g","Value":"_, _","Tokens":null,"Policy":[["alice","data2_admin"]],"PolicyMap":{"alice,data2_admin":0},"RM":{}}},"logger":{"logger":{"Key":"","Value":"","Tokens":null,"Policy":null,"PolicyMap":null,"RM":null}},"m":{"m":{"Key":"m","Value":"g(r_sub, p_sub) \u0026\u0026 r_obj == p_obj \u0026\u0026 r_act == p_act","Tokens":null,"Policy":null,"PolicyMap":{},"RM":null}},"p":{"p":{"Key":"p","Value":"sub, obj, act","Tokens":["p_sub","p_obj","p_act"],"Policy":[["alice","data1","read"],["bob","data2","write"],["data2_admin","data2","read"],["data2_admin","data2","write"]],"PolicyMap":{"alice,data1,read":0,"bob,data2,write":1,"data2_admin,data2,read":2,"data2_admin,data2,write":3},"RM":null}},"r":{"r":{"Key":"r","Value":"sub, obj, act","Tokens":["r_sub","r_obj","r_act"],"Policy":null,"PolicyMap":{},"RM":null}}}`
-			expected := model.Model{}
-			_ = json.Unmarshal([]byte(s), &expected)
-			bytes, _ := json.Marshal(params)
-			res := model.Model{}
-			_ = json.Unmarshal(bytes, &res)
-			if !reflect.DeepEqual(res.GetPolicy("p", "p"), expected.GetPolicy("p", "p")) {
-				t.Fatalf("instance Params should be %#v instead of %#v", expected, res)
-			}
-			if !reflect.DeepEqual(res.GetPolicy("g", "g"), expected.GetPolicy("g", "g")) {
-				t.Fatalf("instance Params should be %#v instead of %#v", expected, res)
+			res := params.(string)
+			if res != "" {
+				t.Fatalf("instance Params should be empty instead of %s", res)
 			}
 		})
 	})


### PR DESCRIPTION
This PR adds a default WatcherEx update callback for supporting the incremental update.

fixed: https://github.com/casbin/casbin/issues/999 
fixed: https://github.com/casbin/redis-watcher/issues/28
