### PR TITLE
feat: use redis UniversalClient interface

### DIFF
--- a/options.go
+++ b/options.go
@@ -8,8 +8,8 @@ import (
 type WatcherOptions struct {
 	Options                rds.Options
 	ClusterOptions         rds.ClusterOptions
-	SubClient              *rds.Client
-	PubClient              *rds.Client
+	SubClient              rds.UniversalClient
+	PubClient              rds.UniversalClient
 	Channel                string
 	IgnoreSelf             bool
 	LocalID                string


### PR DESCRIPTION
use `UniversalClient` interface for `WatcherOptions` SubClient and PubClient, so the Redis `Client`, `FailoverClient` or `ClusterClient` can be used.


[Redis UniversalClient](https://github.com/redis/go-redis/blob/c0ab7815ea66b036d0cb02e2902a7820551d948a/universal.go#L199)